### PR TITLE
Escape the titles in Atom feed

### DIFF
--- a/feed.atom
+++ b/feed.atom
@@ -2,15 +2,15 @@
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-    <title type="text" xml:lang="en">{{ site.title }}</title>
-    <author><name>{{ site.author }}</name></author>
+    <title type="text" xml:lang="en">{{ site.title | xml_escape }}</title>
+    <author><name>{{ site.author | xml_escape }}</name></author>
     <link type="application/atom+xml" href="{{ site.url }}/feed.atom" rel="self"/>
     <link href="{{ site.url }}/" rel="alternate"/>
     <updated>{{ site.time | date_to_xmlschema }}</updated>
     <id>{{ site.url }}/</id>
     {% for post in site.posts limit:20 %}
     <entry>
-        <title>{{ post.title }}</title>
+        <title>{{ post.title | xml_escape }}</title>
         <link href="{{ site.url }}{{ post.url }}"/>
         <updated>{{ post.date | date_to_xmlschema }}</updated>
         <id>{{ site.url }}{{ post.url }}</id>


### PR DESCRIPTION
Fixes the feed being rejected by rigorous XML parsers.